### PR TITLE
Optimize ArgoCD install step

### DIFF
--- a/gitops-playground/index.json
+++ b/gitops-playground/index.json
@@ -1,6 +1,6 @@
 {
   "title": "gitops-playground",
-  "description": "playground with Circle CI,Argocd,Docker,k8s,kustomize,sealed-secrets",
+  "description": "Playground with CircleCI, Argocd, Docker, k8s, kustomize, sealed-secrets",
   "difficulty": "Intermediate",
   "time": "30mins",
   "details": {

--- a/gitops-playground/steps/install-argocd.md
+++ b/gitops-playground/steps/install-argocd.md
@@ -1,5 +1,15 @@
-`kubectl create namespace argocd
-kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml`{{execute}}
+Download install yaml for ArgoCD
 
-`sudo curl -L https://github.com/argoproj/argo-cd/releases/download/v1.3.0/argocd-linux-amd64 -o /usr/local/bin/argocd
+`curl -L https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml > ~/argocd-install.yaml`
+
+Install ArgoCD in k8s
+
+`kubectl create namespace argocd
+kubectl apply -n argocd -f ~/argocd-install.yaml`{{execute}}
+
+Install ArgoCD client
+
+`ARGOCD_VERSION=$(cat ~/argocd-install.yaml | grep -m1 argoproj/argocd | cut -d ":" -f3)
+sudo curl -L https://github.com/argoproj/argo-cd/releases/download/$ARGOCD_VERSION/argocd-linux-amd64 -o /usr/local/bin/argocd
 sudo chmod +x /usr/local/bin/argocd`{{execute}}
+


### PR DESCRIPTION
# Why
* Current ArgoCD install step can lead to mismatch versions between ArgoCD client and server

# What
* Use version of ArgoCD image declared in install yaml to decide version for ArgoCD client.

# Minor change
* Add spaces after commas in description.
